### PR TITLE
Added a endpoint to check submissions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,34 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+annotated-types = "==0.7.0"
+anyio = "==4.9.0"
+click = "==8.2.0"
+fastapi = "==0.115.12"
+filelock = "==3.18.0"
+h11 = "==0.16.0"
+httptools = "==0.6.4"
+idna = "==3.10"
+psycopg2-binary = "==2.9.10"
+pydantic-core = "==2.33.2"
+python-dotenv = "==1.1.0"
+pyyaml = "==6.0.2"
+sniffio = "==1.3.1"
+sqlalchemy = "==2.0.41"
+starlette = "==0.46.2"
+typing-inspection = "==0.4.0"
+typing-extensions = "==4.13.2"
+uvicorn = "==0.34.2"
+uvloop = "==0.21.0"
+watchfiles = "==1.0.5"
+websockets = "==15.0.1"
+pydantic = {extras = ["email"], version = "*"}
+alembic = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.13"

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from sqlalchemy.orm import Session
 from app.db import models
 from datetime import datetime
@@ -70,3 +71,14 @@ def create_or_update_otp(db, email, otp, expires_at):
         entry = models.OTP(email=email, otp=otp, expires_at=expires_at)
         db.add(entry)
     db.commit()
+
+
+def get_submissions(db: Session, email: str, track_id: Optional[int] = None):
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if not user:
+        return []
+    query = db.query(models.Submission).filter(models.Submission.mentee_id == user.id)
+    if track_id is not None:
+        query = query.join(models.Task, models.Submission.task_id == models.Task.id)
+        query = query.filter(models.Task.track_id == track_id)
+    return query.all()

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from app.db.db import Base, engine
-from app.routes import auth, progress, tracks, leaderboard, mentors
+from app.routes import auth, progress, tracks, leaderboard, mentors , submissions
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(title="amMentor API")
@@ -23,7 +23,7 @@ app.include_router(progress.router, prefix="/progress", tags=["Progress"])
 app.include_router(tracks.router, prefix="/tracks", tags=["Tracks"])
 app.include_router(leaderboard.router, prefix="/leaderboard", tags=["Leaderboard"])
 app.include_router(mentors.router, prefix="/mentors", tags=["Mentors"])
-
+app.include_router(submissions.router, prefix="/submissions", tags=["Submissions"])
 
 @app.get("/")
 def root():

--- a/app/routes/submissions.py
+++ b/app/routes/submissions.py
@@ -1,0 +1,19 @@
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException , Query
+from sqlalchemy.orm import Session
+from app.db import crud
+from app.db.db import get_db
+from app.schemas.submission import SubmissionOut
+
+router = APIRouter()
+
+@router.get("/", response_model=list[SubmissionOut])
+def get_submissions(
+    email: str = Query(...), 
+    track_id: Optional[int] = Query(None), 
+    db: Session = Depends(get_db)
+):
+    submissions = crud.get_submissions(db, email, track_id)
+    if not submissions:
+        raise HTTPException(status_code=404, detail="No submissions found")
+    return submissions


### PR DESCRIPTION
New route added at /submissions/ to retrieve submissions dynamically using email as a query parameter.

Optionally filters results by track_id via query string:
```
GET /submissions?email=user@example.com&track_id=2
```

