### PR TITLE
Fix submission date handling and include start_date in API response

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -19,7 +19,7 @@ def submit_task(db: Session, mentee_id: int, task_id: int, reference_link: str,s
         mentee_id=mentee_id,
         task_id=task_id,
         reference_link=reference_link,
-        submitted_at=date,
+        submitted_at=date.today(),
         status="submitted",
         start_date=start_date,
         

--- a/app/routes/submissions.py
+++ b/app/routes/submissions.py
@@ -13,7 +13,7 @@ def get_submissions(
     track_id: Optional[int] = Query(None), 
     db: Session = Depends(get_db)
 ):
-    submissions = crud.get_submissions(db, email, track_id)
+    submissions = crud.get_submissions(db, email, track_id,)
     if not submissions:
         raise HTTPException(status_code=404, detail="No submissions found")
     return submissions

--- a/app/schemas/submission.py
+++ b/app/schemas/submission.py
@@ -6,7 +6,7 @@ class SubmissionBase(BaseModel):
     track_id: int
     task_no: int
     reference_link: str
-    start_date:date
+    start_date: date
 class SubmissionCreate(SubmissionBase):
     mentee_email: str
 
@@ -19,8 +19,8 @@ class SubmissionOut(BaseModel):
     status: str
     submitted_at: date
     approved_at: Optional[date] = None
-    mentor_feedback: Optional[str] = None
-
+    mentor_feedback: Optional[str] = None   
+    start_date: date
     class Config:
         orm_mode = True
 


### PR DESCRIPTION
### What’s fixed:
- Replaced incorrect usage of `submitted_at = date` with `submitted_at = date.today()` to fix `can't adapt type 'type'` error from psycopg2.
- Ensured `start_date` is properly passed and stored.
- Updated `SubmissionOut` Pydantic schema to include `start_date` in API response.

### Why:
The previous implementation attempted to insert a Python `type` instead of a value, causing a runtime error. Also, `start_date` was not visible in the response due to missing schema mapping.

### Testing:
- Manually tested via Swagger/FastAPI UI — verified `start_date` now appears correctly in the submission response.