### PR TITLE
fix: map deadline_days from DB to deadline in API response

### DIFF
--- a/app/routes/tracks.py
+++ b/app/routes/tracks.py
@@ -17,4 +17,5 @@ def list_tasks_for_track(track_id: int, db: Session = Depends(get_db)):
     if not track:
         raise HTTPException(status_code=404, detail="Track not found")
 
-    return db.query(models.Task).filter_by(track_id=track_id).order_by(models.Task.task_no).all()
+    tasks = db.query(models.Task).filter_by(track_id=track_id).order_by(models.Task.task_no).all()
+    return [TaskOut.from_orm(task) for task in tasks]

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -8,13 +8,31 @@ class TaskBase(BaseModel):
     title: str
     description: Optional[str] = None
     points: int = 10
-    deadline: Optional[datetime] = None 
+    deadline_days: Optional[datetime] = None 
 
 class TaskCreate(TaskBase):
     pass
 
-class TaskOut(TaskBase):
+class TaskOut(BaseModel):
     id: int
+    track_id: int
+    task_no: int
+    title: str
+    description: Optional[str]
+    points: int
+    deadline: Optional[int]
 
     class Config:
         orm_mode = True
+
+    @classmethod
+    def from_orm(cls, obj):
+        return cls(
+            id=obj.id,
+            track_id=obj.track_id,
+            task_no=obj.task_no,
+            title=obj.title,
+            description=obj.description,
+            points=obj.points,
+            deadline=obj.deadline_days
+        )


### PR DESCRIPTION
This PR fixes an issue where the deadline field in the task API response was showing null despite values being present in the database.

Changes Made:
- Updated TaskOut schema to manually define fields instead of inheriting from TaskBase
- Mapped deadline_days (from DB model) to deadline (in API) using a custom from_orm() method
- Updated the /track_id/tasks route to explicitly call TaskOut.from_orm() for each task
