### PR TITLE
Fix approved_at field to return date instead of datetime

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -38,7 +38,7 @@ def approve_submission(db: Session, submission_id: int, mentor_feedback: str, st
     sub.status = status
     sub.mentor_feedback = mentor_feedback
     if status == "approved":
-        sub.approved_at = datetime.utcnow()
+        sub.approved_at = date.today()
 
     db.commit()
     db.refresh(sub)


### PR DESCRIPTION
This PR fixes a response validation error caused by a mismatch between the `approved_at` field and the response schema. 

- The response model expected a `date`, but a full `datetime` was being returned.
- Updated the `approve_submission` logic to use `.date()` to ensure compatibility.
- This resolves the FastAPI `date_from_datetime_inexact` error and ensures clean API output.

Tested locally — all responses now validate correctly.