### PR TITLE
Add task_name to the submission schema

### DIFF
--- a/app/schemas/submission.py
+++ b/app/schemas/submission.py
@@ -15,6 +15,7 @@ class SubmissionOut(BaseModel):
     id: int
     mentee_id: int
     task_id: int
+    task_name: str 
     reference_link: str
     status: str
     submitted_at: date


### PR DESCRIPTION
### Description
This PR enhances the get_submissions endpoint by including the task_name (i.e., Task.title) in the response. This allows frontend consumers to directly display the name of the task associated with each submission, improving the clarity of the review and listing interfaces.

### Changes Made:
- Updated SubmissionOut Pydantic schema to include a task_name field.
- Modified the get_submissions function to:
- Use joinedload to eager-load related Task objects.
- Extract task.title from each Submission and include it as task_name in the response.

### Impact:
- The frontend can now render the task name directly without making an additional API call.
- Fully backward-compatible with existing logic (no field removed or renamed).
- 
### Testing:
- Verified response structure includes task_name as expected.
- Confirmed correct values are fetched for all submissions with joined Task relationships.